### PR TITLE
FEAT-7 - Introduced Participant Data Model

### DIFF
--- a/fdn_participant/constants.py
+++ b/fdn_participant/constants.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class REVIEW_STATUS(Enum):
+    NOT_REVIEWED = 'Not Reviewed'
+    ACCEPTED = 'Reviewed - Accepted'
+    NOT_ACCEPTED = 'Reviewed - Not Accepted'

--- a/fdn_participant/models.py
+++ b/fdn_participant/models.py
@@ -1,5 +1,14 @@
 from django.db import models
 
+from .constants import REVIEW_STATUS
+
+
+class EnvExposure(models.Model):
+    exposure_name = models.CharField(max_length=1000)
+
+    def __str__(self):
+        return self.exposure_name
+
 
 class GeneMutation(models.Model):
     gene_name = models.CharField(max_length=1000)
@@ -8,8 +17,16 @@ class GeneMutation(models.Model):
         return self.gene_name
 
 
-class EnvExposure(models.Model):
-    exposure_name = models.CharField(max_length=1000)
+class Participant(models.Model):
+    name = models.CharField(max_length=255)
+    age = models.PositiveIntegerField()
+    has_siblings = models.BooleanField()
+    env_exposures = models.ManyToManyField(EnvExposure)
+    gene_mutations = models.ManyToManyField(GeneMutation)
+    reviewed_status = models.CharField(
+        max_length=255,
+        choices=[(tag, tag.value) for tag in REVIEW_STATUS],
+        default=REVIEW_STATUS.NOT_REVIEWED)
 
     def __str__(self):
-        return self.exposure_name
+        return self.name


### PR DESCRIPTION
Introduced Participant Data Model. Introduced environmental exposure and gene exposure as many-to-many relationships with the lookup tables and reviewed status as a char field enum

Story Link: <blockquote class="trello-card"><a href="https://trello.com/c/S1ZFDj32/20-create-participant-data-model-feat-7">Create Participant Data Model (FEAT-7)</a></blockquote>