### PR TITLE
FEAT-12 - Migrate FDN_Site Schema to AWS RDS Postgresql fdndata database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea/dataSources.xml

--- a/fdn_site/settings.py
+++ b/fdn_site/settings.py
@@ -67,8 +67,12 @@ WSGI_APPLICATION = 'fdn_site.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'fdndata'),
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'fdndata',
+        'USER': 'butcer0',
+        'PASSWORD': 'compuwhz',
+        'HOST': 'fdn-data-instance.crmwiup4nfik.us-east-1.rds.amazonaws.com',
+        'PORT': '5432',
     }
 }
 
@@ -111,3 +115,14 @@ STATIC_URL = '/static/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
 MEDIA_URL = '/media/'
+
+"""
+all matching properties in local_settings will overwrite existing
+can include this empty local, then include the local_settings.py
+to overwrite the values on the server
+"""
+
+try:
+    from .local_settings import *
+except ImportError:
+    pass


### PR DESCRIPTION
Migrate FDN_Site Schema to AWS RDS Postgresql fdndata database

Story Link: <blockquote class="trello-card"><a href="https://trello.com/c/ZgNXoRPz/27-migrate-fdnsite-schemas-to-aws-rds-postgresql-fdndata-database-feat-12">Migrate `FDN_Site` Schemas to AWS RDS Postgresql `fdn_data` Database (FEAT-12)</a></blockquote>